### PR TITLE
Implement skip list for Memtable

### DIFF
--- a/internal/memtable/algorithm/skip_list.go
+++ b/internal/memtable/algorithm/skip_list.go
@@ -1,37 +1,178 @@
 package algorithm
 
-import "github.com/richardktran/lsm-tree-go-my-way/internal/kv"
+import (
+	"math/rand"
+
+	"github.com/richardktran/lsm-tree-go-my-way/internal/kv"
+)
 
 var _ SortedList = (*SkipList)(nil)
 
-type SkipList struct{}
+const (
+	maxLevel    = 16
+	probability = 0.5
+)
 
-// Clone implements SortedList.
-func (s *SkipList) Clone() SortedList {
-	panic("unimplemented")
+type skipListNode struct {
+	key   kv.Key
+	value kv.Value
+	next  []*skipListNode
 }
 
-// Delete implements SortedList.
-func (s *SkipList) Delete(key kv.Key) {
-	panic("unimplemented")
+func newSkipListNode(key kv.Key, value kv.Value, level int) *skipListNode {
+	return &skipListNode{
+		key:   key,
+		value: value,
+		next:  make([]*skipListNode, level),
+	}
 }
 
-// Get implements SortedList.
+// SkipList is a probabilistic sorted data structure providing O(log n) average
+// complexity for Get, Set, and Delete — replacing the O(n log n) SortedArray.
+type SkipList struct {
+	head  *skipListNode // sentinel head; its key is never compared
+	level int           // highest level currently in use (1-indexed)
+	size  int           // total byte size: sum of len(key)+len(value) for all nodes
+}
+
+func NewSkipList() *SkipList {
+	return &SkipList{
+		head:  newSkipListNode("", nil, maxLevel),
+		level: 1,
+	}
+}
+
+// BuildSkipList constructs a SkipList from a pre-existing slice of records.
+// Input order does not matter; all records are inserted individually.
+func BuildSkipList(data []kv.Record) *SkipList {
+	s := NewSkipList()
+	for _, r := range data {
+		s.Set(r.Key, r.Value)
+	}
+	return s
+}
+
+// randomLevel picks a new node height using the geometric distribution with p=0.5.
+func (s *SkipList) randomLevel() int {
+	level := 1
+	for level < maxLevel && rand.Float64() < probability {
+		level++
+	}
+	return level
+}
+
+// Get returns the value stored for key and true, or ("", false) if not present.
+// A node storing a nil value (tombstone) returns (nil, true).
 func (s *SkipList) Get(key kv.Key) (kv.Value, bool) {
-	panic("unimplemented")
+	current := s.head
+	for i := s.level - 1; i >= 0; i-- {
+		for current.next[i] != nil && current.next[i].key < key {
+			current = current.next[i]
+		}
+	}
+	candidate := current.next[0]
+	if candidate != nil && candidate.key == key {
+		return candidate.value, true
+	}
+	return kv.Value(""), false
 }
 
-// GetAll implements SortedList.
-func (s *SkipList) GetAll() []kv.Record {
-	panic("unimplemented")
-}
-
-// Set implements SortedList.
+// Set inserts or updates the value for key in O(log n) average time.
 func (s *SkipList) Set(key kv.Key, value kv.Value) {
-	panic("unimplemented")
+	// update[i] is the rightmost node at level i whose next key < key
+	update := make([]*skipListNode, maxLevel)
+	current := s.head
+
+	for i := s.level - 1; i >= 0; i-- {
+		for current.next[i] != nil && current.next[i].key < key {
+			current = current.next[i]
+		}
+		update[i] = current
+	}
+
+	candidate := current.next[0]
+	if candidate != nil && candidate.key == key {
+		// Key already exists: update value in place, adjust byte size.
+		s.size -= kv.Record{Key: key, Value: candidate.value}.Size()
+		s.size += kv.Record{Key: key, Value: value}.Size()
+		candidate.value = value
+		return
+	}
+
+	// New key: pick a random level and splice in the new node.
+	newLevel := s.randomLevel()
+	if newLevel > s.level {
+		for i := s.level; i < newLevel; i++ {
+			update[i] = s.head
+		}
+		s.level = newLevel
+	}
+
+	node := newSkipListNode(key, value, newLevel)
+	for i := 0; i < newLevel; i++ {
+		node.next[i] = update[i].next[i]
+		update[i].next[i] = node
+	}
+
+	s.size += kv.Record{Key: key, Value: value}.Size()
 }
 
-// Size implements SortedList.
+// Delete removes the node with the given key in O(log n) average time.
+func (s *SkipList) Delete(key kv.Key) {
+	update := make([]*skipListNode, maxLevel)
+	current := s.head
+
+	for i := s.level - 1; i >= 0; i-- {
+		for current.next[i] != nil && current.next[i].key < key {
+			current = current.next[i]
+		}
+		update[i] = current
+	}
+
+	target := current.next[0]
+	if target == nil || target.key != key {
+		return // key not present
+	}
+
+	for i := 0; i < s.level; i++ {
+		if update[i].next[i] != target {
+			break
+		}
+		update[i].next[i] = target.next[i]
+	}
+
+	s.size -= kv.Record{Key: key, Value: target.value}.Size()
+
+	// Shrink level if top levels are now empty.
+	for s.level > 1 && s.head.next[s.level-1] == nil {
+		s.level--
+	}
+}
+
+// Size returns the total byte footprint of all key-value pairs.
 func (s *SkipList) Size() int {
-	panic("unimplemented")
+	return s.size
+}
+
+// GetAll returns all records in sorted key order by traversing level 0.
+func (s *SkipList) GetAll() []kv.Record {
+	var records []kv.Record
+	for node := s.head.next[0]; node != nil; node = node.next[0] {
+		records = append(records, kv.Record{Key: node.key, Value: node.value})
+	}
+	return records
+}
+
+// Clone returns an independent deep copy of the skip list.
+func (s *SkipList) Clone() SortedList {
+	dst := NewSkipList()
+	for node := s.head.next[0]; node != nil; node = node.next[0] {
+		var valueCopy kv.Value
+		if node.value != nil {
+			valueCopy = make(kv.Value, len(node.value))
+			copy(valueCopy, node.value)
+		}
+		dst.Set(node.key, valueCopy)
+	}
+	return dst
 }

--- a/internal/memtable/algorithm/skip_list_test.go
+++ b/internal/memtable/algorithm/skip_list_test.go
@@ -1,0 +1,156 @@
+package algorithm
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/richardktran/lsm-tree-go-my-way/internal/kv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipList(t *testing.T) {
+	for scenario, fn := range map[string]func(t *testing.T, sl *SkipList){
+		"get/set key on SkipList":           testSkipListGetSet,
+		"delete key on SkipList":            testSkipListDelete,
+		"get size of the SkipList":          testSkipListSize,
+		"get all records in sorted order":   testSkipListGetAllSorted,
+		"insert a record with the same key": testSkipListUpsert,
+		"clone the SkipList":                testSkipListClone,
+		"set tombstone (nil value)":         testSkipListTombstone,
+		"build SkipList from records":       testBuildSkipList,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			sl := NewSkipList()
+			fn(t, sl)
+		})
+	}
+}
+
+func testSkipListGetSet(t *testing.T, sl *SkipList) {
+	// Insert keys out of order to confirm sorted traversal.
+	for i := 5; i >= 0; i-- {
+		key := kv.Key("k" + strconv.Itoa(i))
+		value := kv.Value("v" + strconv.Itoa(i))
+		sl.Set(key, value)
+
+		v, found := sl.Get(key)
+		require.True(t, found)
+		require.Equal(t, value, v)
+
+		require.True(t, skipListSorted(sl), "order invariant violated after inserting %s", key)
+	}
+}
+
+func testSkipListDelete(t *testing.T, sl *SkipList) {
+	for i := 0; i < 5; i++ {
+		sl.Set(kv.Key("k"+strconv.Itoa(i)), kv.Value("v"+strconv.Itoa(i)))
+	}
+
+	sl.Delete(kv.Key("k3"))
+	_, found := sl.Get(kv.Key("k3"))
+	require.False(t, found)
+
+	// Remaining keys are still accessible and in order.
+	require.True(t, skipListSorted(sl))
+	require.Equal(t, 4, len(sl.GetAll()))
+}
+
+func testSkipListSize(t *testing.T, sl *SkipList) {
+	for i := 0; i < 5; i++ {
+		sl.Set(kv.Key("k"+strconv.Itoa(i)), kv.Value("v"+strconv.Itoa(i)))
+	}
+	// "k0"+"v0" = 4 bytes, × 5 = 20 bytes
+	require.Equal(t, 20, sl.Size())
+
+	sl.Set(kv.Key("k33232"), kv.Value("khoa dep trai qua"))
+	require.Equal(t, 43, sl.Size())
+}
+
+func testSkipListGetAllSorted(t *testing.T, sl *SkipList) {
+	for i := 0; i < 5; i++ {
+		sl.Set(kv.Key("k"+strconv.Itoa(i)), kv.Value("v"+strconv.Itoa(i)))
+	}
+
+	records := sl.GetAll()
+	for i := 1; i < len(records); i++ {
+		require.True(t, records[i-1].Key <= records[i].Key,
+			"records not sorted: %s > %s", records[i-1].Key, records[i].Key)
+	}
+}
+
+func testSkipListUpsert(t *testing.T, sl *SkipList) {
+	sl.Set(kv.Key("k1"), kv.Value("v1"))
+	v, found := sl.Get(kv.Key("k1"))
+	require.True(t, found)
+	require.Equal(t, kv.Value("v1"), v)
+
+	// Overwrite — size should stay the same (same key/value length).
+	sl.Set(kv.Key("k1"), kv.Value("v2"))
+	v, found = sl.Get(kv.Key("k1"))
+	require.True(t, found)
+	require.Equal(t, kv.Value("v2"), v)
+	require.Equal(t, 1, len(sl.GetAll()), "upsert must not create duplicate nodes")
+}
+
+func testSkipListClone(t *testing.T, sl *SkipList) {
+	for i := 0; i < 5; i++ {
+		sl.Set(kv.Key("k"+strconv.Itoa(i)), kv.Value("v"+strconv.Itoa(i)))
+	}
+
+	clone := sl.Clone()
+	require.Equal(t, sl.Size(), clone.Size())
+	require.Equal(t, sl.GetAll(), clone.GetAll())
+
+	// Mutating the original must not affect the clone.
+	sl.Set(kv.Key("k1"), kv.Value("v2"))
+	origVal, _ := sl.Get(kv.Key("k1"))
+	require.Equal(t, kv.Value("v2"), origVal)
+
+	cloneVal, found := clone.Get(kv.Key("k1"))
+	require.True(t, found)
+	require.Equal(t, kv.Value("v1"), cloneVal)
+}
+
+func testSkipListTombstone(t *testing.T, sl *SkipList) {
+	sl.Set(kv.Key("k1"), kv.Value("v1"))
+	sizeWithValue := sl.Size()
+
+	// Store a nil value (tombstone).
+	sl.Set(kv.Key("k1"), nil)
+	val, found := sl.Get(kv.Key("k1"))
+	require.True(t, found, "tombstone node must be found")
+	require.Nil(t, val, "tombstone value must be nil")
+
+	// Size should reflect key-only (len("k1") = 2, len(nil) = 0).
+	require.Less(t, sl.Size(), sizeWithValue)
+	require.Equal(t, len("k1"), sl.Size())
+}
+
+func testBuildSkipList(t *testing.T, _ *SkipList) {
+	records := []kv.Record{
+		{Key: "k3", Value: kv.Value("v3")},
+		{Key: "k1", Value: kv.Value("v1")},
+		{Key: "k2", Value: kv.Value("v2")},
+	}
+	sl := BuildSkipList(records)
+
+	all := sl.GetAll()
+	require.Len(t, all, 3)
+	require.Equal(t, kv.Key("k1"), all[0].Key)
+	require.Equal(t, kv.Key("k2"), all[1].Key)
+	require.Equal(t, kv.Key("k3"), all[2].Key)
+
+	require.Equal(t, 12, sl.Size()) // 3×(2+2) = 12 bytes
+}
+
+// skipListSorted returns true when level-0 traversal is in non-decreasing key order.
+func skipListSorted(sl *SkipList) bool {
+	node := sl.head.next[0]
+	for node != nil && node.next[0] != nil {
+		if node.key > node.next[0].key {
+			return false
+		}
+		node = node.next[0]
+	}
+	return true
+}

--- a/internal/memtable/memtable.go
+++ b/internal/memtable/memtable.go
@@ -14,7 +14,7 @@ type MemTable struct {
 
 func NewMemTable() *MemTable {
 	return &MemTable{
-		sortedData: algorithm.NewSortedArray(),
+		sortedData: algorithm.NewSkipList(),
 	}
 }
 
@@ -75,7 +75,7 @@ func LoadFromWAL(wal *wal.WAL) (*MemTable, error) {
 	}
 
 	if len(records) > 0 {
-		memTable.sortedData = algorithm.BuildSortedArray(records)
+		memTable.sortedData = algorithm.BuildSkipList(records)
 	}
 
 	return memTable, nil

--- a/internal/sstable/sstable.go
+++ b/internal/sstable/sstable.go
@@ -358,7 +358,9 @@ func (s *SSTable) persistSparseIndex() {
 func (s *SSTable) recoverSparseIndex(filePath string) {
 	sparseLogFile, err := os.Open(filePath)
 	if err != nil {
-		log.Println("Error opening sparse index file: ", err)
+		if !os.IsNotExist(err) {
+			log.Println("Error opening sparse index file: ", err)
+		}
 		return
 	}
 	defer sparseLogFile.Close()


### PR DESCRIPTION
## Summary
- Implement a probabilistic SkipList (`maxLevel=16`, `p=0.5`) as the MemTable’s `SortedList` backend, replacing `SortedArray`.
- MemTable create/load paths now use `NewSkipList` / `BuildSkipList`, so Get/Set/Delete are O(log n) average instead of re-sorting on every write (O(n log n)).
- Add unit tests covering get/set, delete, upsert, sorted `GetAll`, size accounting, tombstones, clone, and `BuildSkipList`.
- Quiet the false-positive “Error opening sparse index file” log when creating a new SSTable (missing `.index` is expected).

## Motivation
`SortedArray` kept keys ordered by sorting after each insert. A SkipList keeps the memtable sorted structurally while making writes much cheaper as the memtable grows, without changing the `SortedList` interface used by the rest of the LSM path.

## Test plan
- [x] `go test ./internal/memtable/...`
- [x] `go test ./internal/store/lsmtree/...`
- [x] `make test` (or `go test -race ./...`)